### PR TITLE
Build Docker image with Python 3.13 and trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.13-slim-trixie
 
 ARG VERSION
 


### PR DESCRIPTION
Only to avoid tech debt. These are current stable versions of Python and Debian, respectively.