### PR TITLE
fix: BCE-9443 - handle empty string fee_recipient, fix signer_keys tuple bug

### DIFF
--- a/sync_keys/sync_validator_keys.py
+++ b/sync_keys/sync_validator_keys.py
@@ -126,7 +126,7 @@ def _generate_lighthouse_config(
                 "type": "web3signer",
                 "url": web3signer_url,
                 "suggested_fee_recipient": (
-                    fee_recipient if fee_recipient is not None else default_recipient
+                    fee_recipient if fee_recipient else default_recipient
                 ),
             }
         )
@@ -152,5 +152,5 @@ def _generate_signer_keys_config(
     """
     Generate config for Teku and Prysm clients
     """
-    keys = ",".join([f'"{public_key}"' for public_key in public_keys_with_recipient])
+    keys = ",".join([f'"{public_key}"' for public_key, _ in public_keys_with_recipient])
     return f"""validators-external-signer-public-keys: [{keys}]"""

--- a/tests/test_sync_validator_keys.py
+++ b/tests/test_sync_validator_keys.py
@@ -1,0 +1,118 @@
+import sys
+from pathlib import Path
+
+import yaml
+
+# Add sync_keys to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "sync_keys"))
+
+from sync_validator_keys import _generate_lighthouse_config, _generate_signer_keys_config
+
+
+DEFAULT_RECIPIENT = "0x1111111111111111111111111111111111111111"
+WEB3SIGNER_URL = "http://web3signer:9000"
+
+
+class TestGenerateLighthouseConfig:
+    def test_valid_fee_recipient_is_used(self):
+        """When fee_recipient is a valid address, it should be used directly."""
+        fee_recipient = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        keys = [("0xpubkey1", fee_recipient)]
+
+        result = yaml.safe_load(
+            _generate_lighthouse_config(keys, WEB3SIGNER_URL, DEFAULT_RECIPIENT)
+        )
+
+        assert result[0]["suggested_fee_recipient"] == fee_recipient
+
+    def test_none_fee_recipient_falls_back_to_default(self):
+        """When fee_recipient is None, the default should be used."""
+        keys = [("0xpubkey1", None)]
+
+        result = yaml.safe_load(
+            _generate_lighthouse_config(keys, WEB3SIGNER_URL, DEFAULT_RECIPIENT)
+        )
+
+        assert result[0]["suggested_fee_recipient"] == DEFAULT_RECIPIENT
+
+    def test_empty_string_fee_recipient_falls_back_to_default(self):
+        """When fee_recipient is empty string, the default should be used."""
+        keys = [("0xpubkey1", "")]
+
+        result = yaml.safe_load(
+            _generate_lighthouse_config(keys, WEB3SIGNER_URL, DEFAULT_RECIPIENT)
+        )
+
+        assert result[0]["suggested_fee_recipient"] == DEFAULT_RECIPIENT
+
+    def test_mixed_fee_recipients(self):
+        """Keys with valid, None, and empty fee recipients should be handled correctly."""
+        valid_recipient = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        keys = [
+            ("0xpubkey1", valid_recipient),
+            ("0xpubkey2", None),
+            ("0xpubkey3", ""),
+        ]
+
+        result = yaml.safe_load(
+            _generate_lighthouse_config(keys, WEB3SIGNER_URL, DEFAULT_RECIPIENT)
+        )
+
+        assert result[0]["suggested_fee_recipient"] == valid_recipient
+        assert result[1]["suggested_fee_recipient"] == DEFAULT_RECIPIENT
+        assert result[2]["suggested_fee_recipient"] == DEFAULT_RECIPIENT
+
+    def test_config_structure(self):
+        """Generated config should have the correct Lighthouse structure."""
+        keys = [("0xpubkey1", None)]
+
+        result = yaml.safe_load(
+            _generate_lighthouse_config(keys, WEB3SIGNER_URL, DEFAULT_RECIPIENT)
+        )
+
+        entry = result[0]
+        assert entry["enabled"] is True
+        assert entry["voting_public_key"] == "0xpubkey1"
+        assert entry["type"] == "web3signer"
+        assert entry["url"] == WEB3SIGNER_URL
+
+    def test_empty_keys_list(self):
+        """Empty keys list should produce empty YAML list."""
+        result = yaml.safe_load(
+            _generate_lighthouse_config([], WEB3SIGNER_URL, DEFAULT_RECIPIENT)
+        )
+
+        assert result == []
+
+
+class TestGenerateSignerKeysConfig:
+    def test_extracts_public_keys_from_tuples(self):
+        """Should extract only public keys from (pubkey, fee_recipient) tuples."""
+        keys = [
+            ("0xpubkey1", "0xfee1"),
+            ("0xpubkey2", None),
+            ("0xpubkey3", ""),
+        ]
+
+        result = _generate_signer_keys_config(keys, DEFAULT_RECIPIENT)
+
+        assert '"0xpubkey1"' in result
+        assert '"0xpubkey2"' in result
+        assert '"0xpubkey3"' in result
+        # Should NOT contain fee recipients or tuple representations
+        assert "0xfee1" not in result
+        assert "(" not in result
+
+    def test_format(self):
+        """Output should be valid Teku/Prysm signer keys format."""
+        keys = [("0xpubkey1", None)]
+
+        result = _generate_signer_keys_config(keys, DEFAULT_RECIPIENT)
+
+        assert result == 'validators-external-signer-public-keys: ["0xpubkey1"]'
+
+    def test_empty_keys_list(self):
+        """Empty keys list should produce empty signer keys array."""
+        result = _generate_signer_keys_config([], DEFAULT_RECIPIENT)
+
+        assert result == "validators-external-signer-public-keys: []"


### PR DESCRIPTION
## Summary
- Hardens fee_recipient fallback to handle both `None` and `''` (empty string)
- Fixes `_generate_signer_keys_config` tuple unpacking bug
- Adds 9 tests for config generation functions

## Context
The upstream `Keystore` model changed `fee_recipient` default from `NULL` to `''`. This caused `sync-keys` to use an empty string as the `suggested_fee_recipient` instead of falling back to `--default-recipient`. Additionally, `_generate_signer_keys_config` was iterating `(pubkey, fee_recipient)` tuples as strings instead of unpacking them.

## What Changed
| File | Change |
|------|--------|
| `sync_keys/sync_validator_keys.py:129` | `fee_recipient if fee_recipient is not None` -> `fee_recipient if fee_recipient` |
| `sync_keys/sync_validator_keys.py:155` | `for public_key in ...` -> `for public_key, _ in ...` (tuple unpacking) |
| `tests/test_sync_validator_keys.py` | New: 9 tests covering `_generate_lighthouse_config` and `_generate_signer_keys_config` |

## Test Plan
- [x] All 52 tests pass (`pytest tests/ -v`)
- [x] `fee_recipient=None` -> uses default_recipient
- [x] `fee_recipient=''` -> uses default_recipient
- [x] `fee_recipient='0x...'` -> uses provided address
- [x] Signer keys config correctly extracts pubkeys from tuples